### PR TITLE
user nonexistance error

### DIFF
--- a/mining/DBInterface.py
+++ b/mining/DBInterface.py
@@ -179,6 +179,13 @@ class DBInterface():
                 self.dbi.insert_worker(uid, username, password)
                 self.cache.set(username, password)
                 return True
+            else:
+                self.dbi.insert_user(username, password)
+                if self.dbi.get_uid(username) != False:
+                    uid = self.dbi.get_uid(username)
+                    self.dbi.insert_worker(uid, username, password)
+                    self.cache.set(username, password)
+                    return True
         
         log.info("Authentication for %s failed" % username)
         return False


### PR DESCRIPTION
some servers like to allow people to connect with no signup. this avoids the issue of not having a user created. perhaps missing a uid generator?
