### PR TITLE
SegWit support

### DIFF
--- a/lib/bitcoin_rpc.py
+++ b/lib/bitcoin_rpc.py
@@ -143,12 +143,17 @@ class BitcoinRPC(object):
 
     @defer.inlineCallbacks
     def prevhash(self):
-        resp = (yield self._call('getbestblockhash', []))
         try:
+            resp = (yield self._call('getbestblockhash', []))
             defer.returnValue(json.loads(resp)['result'])
+        # if internal server error try getblocktemplate without empty {} # ppcoin
         except Exception as e:
-            log.exception("Cannot decode prevhash %s" % str(e))
-            raise
+            if (str(e) == "500 Internal Server Error"):
+                resp = (yield self._call('getwork', []))
+                defer.returnValue(util.reverse_hash(json.loads(resp)['result']['data'][8:72]))
+            else:
+                log.exception("Cannot decode prevhash %s" % str(e))
+                raise
         
     @defer.inlineCallbacks
     def validateaddress(self, address):

--- a/lib/bitcoin_rpc.py
+++ b/lib/bitcoin_rpc.py
@@ -11,6 +11,8 @@ import time
 import lib.logger
 log = lib.logger.get_logger('bitcoin_rpc')
 
+gbt_known_rules = ["segwit"]
+
 class BitcoinRPC(object):
     
     def __init__(self, host, port, username, password):
@@ -129,7 +131,7 @@ class BitcoinRPC(object):
     @defer.inlineCallbacks
     def getblocktemplate(self):
         try:
-            resp = (yield self._call('getblocktemplate', [{}]))
+            resp = (yield self._call('getblocktemplate', [{"rules": gbt_known_rules}]))
             defer.returnValue(json.loads(resp)['result'])
         # if internal server error try getblocktemplate without empty {} # ppcoin
         except Exception as e:
@@ -138,12 +140,12 @@ class BitcoinRPC(object):
                 defer.returnValue(json.loads(resp)['result'])
             else:
                 raise
-                                                  
+
     @defer.inlineCallbacks
     def prevhash(self):
-        resp = (yield self._call('getwork', []))
+        resp = (yield self._call('getbestblockhash', []))
         try:
-            defer.returnValue(json.loads(resp)['result']['data'][8:72])
+            defer.returnValue(json.loads(resp)['result'])
         except Exception as e:
             log.exception("Cannot decode prevhash %s" % str(e))
             raise

--- a/lib/block_updater.py
+++ b/lib/block_updater.py
@@ -46,7 +46,7 @@ class BlockUpdater(object):
                 current_prevhash = None
                 
             log.info("Checking for new block.")
-            prevhash = util.reverse_hash((yield self.bitcoin_rpc.prevhash()))
+            prevhash = yield self.bitcoin_rpc.prevhash()
             if prevhash and prevhash != current_prevhash:
                 log.info("New block! Prevhash: %s" % prevhash)
                 update = True

--- a/lib/coinbasetx.py
+++ b/lib/coinbasetx.py
@@ -16,7 +16,7 @@ class CoinbaseTransactionPOW(halfnode.CTransaction):
     extranonce_placeholder = struct.pack(extranonce_type, int('f000000ff111111f', 16))
     extranonce_size = struct.calcsize(extranonce_type)
 
-    def __init__(self, timestamper, coinbaser, value, flags, height, data):
+    def __init__(self, timestamper, coinbaser, value, flags, height, commitment, data):
         super(CoinbaseTransactionPOW, self).__init__()
         log.debug("Got to CoinBaseTX")
         #self.extranonce = 0
@@ -43,7 +43,12 @@ class CoinbaseTransactionPOW(halfnode.CTransaction):
             self.strTxComment = "http://github.com/ahmedbodi/stratum-mining"
         self.vin.append(tx_in)
         self.vout.append(tx_out)
-        
+
+        if(commitment):
+            txout_commitment = halfnode.CTxOut()
+            txout_commitment.nValue = 0
+            txout_commitment.scriptPubKey = commitment
+            self.vout.append(txout_commitment)
         # Two parts of serialized coinbase, just put part1 + extranonce + part2 to have final serialized tx
         self._serialized = super(CoinbaseTransactionPOW, self).serialize().split(self.extranonce_placeholder)
 
@@ -63,7 +68,7 @@ class CoinbaseTransactionPOS(halfnode.CTransaction):
     extranonce_placeholder = struct.pack(extranonce_type, int('f000000ff111111f', 16))
     extranonce_size = struct.calcsize(extranonce_type)
 
-    def __init__(self, timestamper, coinbaser, value, flags, height, data, ntime):
+    def __init__(self, timestamper, coinbaser, value, flags, height, commitment, data, ntime):
         super(CoinbaseTransactionPOS, self).__init__()
         log.debug("Got to CoinBaseTX")
         #self.extranonce = 0
@@ -137,7 +142,13 @@ class CoinbaseTransaction(halfnode.CTransaction):
         self.nTime = ntime 
         self.vin.append(tx_in)
         self.vout.append(tx_out)
-        
+
+        if(commitment):
+            txout_commitment = halfnode.CTxOut()
+            txout_commitment.nValue = 0
+            txout_commitment.scriptPubKey = commitment
+            self.vout.append(txout_commitment)
+
         # Two parts of serialized coinbase, just put part1 + extranonce + part2 to have final serialized tx
         self._serialized = super(CoinbaseTransaction, self).serialize().split(self.extranonce_placeholder)
 

--- a/lib/template_registry.py
+++ b/lib/template_registry.py
@@ -223,24 +223,21 @@ class TemplateRegistry(object):
         else:
             if len(nonce) != 8:
                 raise SubmitException("Incorrect size of nonce. Expected 8 chars")
-        
+
+        # Convert from hex to binary
+        extranonce2_bin = binascii.unhexlify(extranonce2)
+        ntime_bin = binascii.unhexlify(ntime)
+        nonce_bin = binascii.unhexlify(nonce)
+
         # Check for duplicated submit
-        if not job.register_submit(extranonce1_bin, extranonce2, ntime, nonce):
+        if not job.register_submit(extranonce1_bin, extranonce2_bin, ntime_bin, nonce_bin):
             log.info("Duplicate from %s, (%s %s %s %s)" % \
                     (worker_name, binascii.hexlify(extranonce1_bin), extranonce2, ntime, nonce))
             raise SubmitException("Duplicate share")
         
         # Now let's do the hard work!
         # ---------------------------
-        
-        # 0. Some sugar
-        extranonce2_bin = binascii.unhexlify(extranonce2)
-        ntime_bin = binascii.unhexlify(ntime)
-        nonce_bin = binascii.unhexlify(nonce)
-        if settings.COINDAEMON_ALGO == 'riecoin':
-            ntime_bin = (''.join([ ntime_bin[(1-i)*4:(1-i)*4+4] for i in range(0, 2) ]))
-            nonce_bin = (''.join([ nonce_bin[(7-i)*4:(7-i)*4+4] for i in range(0, 8) ]))
-                
+
         # 1. Build coinbase
         coinbase_bin = job.serialize_coinbase(extranonce1_bin, extranonce2_bin)
         coinbase_hash = util.doublesha(coinbase_bin)


### PR DESCRIPTION
This branch has the SegWit commit and another small fix for prevhash. ArtByte 0.13 has been mining Version Bit blocks using this update, it appears to work and is following theuni's code but updated to include Scrypt. However support for SegWit scrypt-jane, skeinhash, quark and riecoin has not been added yet, if you are going to pull please update these as well, it should be easy enough to see where Scrypt has been added in the "SegWit support" commit.